### PR TITLE
Add Senior software eng for housing to join us page

### DIFF
--- a/content/joinus.html
+++ b/content/joinus.html
@@ -52,7 +52,7 @@ the_type = "job-index"
           }})(document, 'script');
         }
     </script>
-    <div class="rbox-opening-li">
+    <div class="rbox-opening-li" style="margin-top:-3rem;margin-bottom: 3rem;">
       <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999763781231-senior-web-developer-9976-1043-digital-services" class="rbox-opening-li-title">
         Senior Software Engineer for Housing
       </a>

--- a/themes/digitalservices/static/css/styles.css
+++ b/themes/digitalservices/static/css/styles.css
@@ -1316,11 +1316,6 @@ ul.left-aligned {
   padding: 50px;
 }
 
-/* Override recruiterbox styling */
-.container div.rbox-widget {
-  margin-bottom: 0.5rem !important;
-}
-
 .separator.center.__web-inspector-hide-shortcut__ {
   display: none;
 }


### PR DESCRIPTION
This adds a hard-coded listing for the Senior Software eng for Housing position to the join us page. 

This is because we want to switch to only using Smart Recruiters for the next round of recruitment.

I was able to re-use the recruiterbox classnames to get the styling to look the same, the remaining item is that I'm having trouble overriding the bottom margin of the section. If the widget is loaded and I update styles.css it works fine, but if the recruiterbox styles load after styles.css then the recruiterbox styles win. 