### PR TITLE
Swap housing eng role for CDSO role

### DIFF
--- a/content/joinus.html
+++ b/content/joinus.html
@@ -52,7 +52,8 @@ the_type = "job-index"
           }})(document, 'script');
         }
     </script> -->
-    <div class="rbox-opening-li" style="margin-top:-3rem;margin-bottom: 3rem;">
+    <!-- Solution for getting opening to fit into Recruiterbox widget -->
+    <!-- <div class="rbox-opening-li" style="margin-top:-3rem;margin-bottom: 3rem;">
       <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999799171175-chief-digital-services-officer-0953-" class="rbox-opening-li-title">
         Chief Digital Services Officer
       </a>
@@ -62,6 +63,16 @@ the_type = "job-index"
           <small class="rbox-opening-position-type">Full-time</small>
         </span>
       </div>
+    </div> -->
+    <div class="rbox-opening-li" style="margin-bottom: 3rem;">
+      <h4>
+        <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999799171175-chief-digital-services-officer-0953-" class="rbox-opening-li-title">
+        Chief Digital Services Officer
+        </a>
+      </h4>
+      <p>
+        Location: San Francisco, California, United States
+      </p>
     </div>
   </div>
 </div>

--- a/content/joinus.html
+++ b/content/joinus.html
@@ -53,8 +53,8 @@ the_type = "job-index"
         }
     </script>
     <div class="rbox-opening-li" style="margin-top:-3rem;margin-bottom: 3rem;">
-      <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999763781231-senior-web-developer-9976-1043-digital-services" class="rbox-opening-li-title">
-        Senior Software Engineer for Housing
+      <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999799171175-chief-digital-services-officer-0953-" class="rbox-opening-li-title">
+        Chief Digital Services Officer
       </a>
       <div class="rbox-job-shortdesc">
         Location: San Francisco, California, United States

--- a/content/joinus.html
+++ b/content/joinus.html
@@ -39,7 +39,7 @@ the_type = "job-index"
   <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-6 col-md-offset-3">
     <h1 class="sub-heading">The Roles</h1>
     <div class="separator center"></div>
-    <script type="text/javascript" id="rbox-loader-script">
+    <!-- <script type="text/javascript" id="rbox-loader-script">
       window._rbox_fixed_header = '.navbar-brand > img';
       if(!window._rbox){
         _rbox = { host_protocol:document.location.protocol, ready:function(cb){this.onready=cb;} };
@@ -51,7 +51,7 @@ the_type = "job-index"
             t.parentNode.insertBefore(s, t.nextSibling);
           }})(document, 'script');
         }
-    </script>
+    </script> -->
     <div class="rbox-opening-li" style="margin-top:-3rem;margin-bottom: 3rem;">
       <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999799171175-chief-digital-services-officer-0953-" class="rbox-opening-li-title">
         Chief Digital Services Officer


### PR DESCRIPTION
Uses my hack to add a non-recruiterbox job opening. In this case, the housing eng position is currently closed, and the CDSO role is on smart recruiters