### PR TITLE
Switch mailchimp with emma sign-up

### DIFF
--- a/themes/digitalservices/layouts/shortcodes/subscribeform.html
+++ b/themes/digitalservices/layouts/shortcodes/subscribeform.html
@@ -8,28 +8,8 @@
     <div class="col-md-12 center">
       <p>If you’d like to hear about future job opportunities and other updates, join our mailing list:</p>
     </div>
-    <div class="col-md-12 contact-form">
-      <style type="text/css">
-        /* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
-        We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-        #mc-embedded-subscribe {
-        min-width: 100%;
-        margin-left: 0;
-        }
-      </style>
-      <div id="mc_embed_signup">
-        <form action="https://sfgov.us15.list-manage.com/subscribe/post?u=b53a43a87ccc9ddbb33b547d1&amp;id=112f8dfe97" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate="">
-          <div id="mc_embed_signup_scroll" class="row">
-            <div class="col-xs-12 col-xs-12 col-md-6 col-md-offset-3 form-group">
-              <label for="mce-EMAIL" style="display:none">Subscribe to our mailing list</label>
-              <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="Email Address" required="">
-              <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-              <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_b53a43a87ccc9ddbb33b547d1_112f8dfe97" tabindex="-1" value=""></div>
-              <div class="clear"><button type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-custom2">Subscribe</button></div>
-            </div>
-          </div>
-        </form>
-      </div>
+    <div class="col-md-12 center">
+      <a type="link" name="subscribe" href="https://app.e2ma.net/app2/audience/signup/1964723/1914840/" class="btn btn-custom2" target="_blank">Subscribe</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
We swapped to sending emails with emma but did not switch the sign-up form. This switches that out. 

Before:
![image](https://user-images.githubusercontent.com/11825994/153504010-ad8c4413-8a24-457a-a27e-69d0c7470889.png)

After:
![image](https://user-images.githubusercontent.com/11825994/153503882-2711fb68-a607-400e-9018-bdcda3ca7125.png)

Decided to not try to make the emma embed look nice since we're moving to SF.gov soon. Just went with a button instead. 