### PR TITLE
Add back recruiterbox

### DIFF
--- a/content/joinus.html
+++ b/content/joinus.html
@@ -39,7 +39,7 @@ the_type = "job-index"
   <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-6 col-md-offset-3">
     <h1 class="sub-heading">The Roles</h1>
     <div class="separator center"></div>
-    <!-- <script type="text/javascript" id="rbox-loader-script">
+    <script type="text/javascript" id="rbox-loader-script">
       window._rbox_fixed_header = '.navbar-brand > img';
       if(!window._rbox){
         _rbox = { host_protocol:document.location.protocol, ready:function(cb){this.onready=cb;} };
@@ -51,9 +51,9 @@ the_type = "job-index"
             t.parentNode.insertBefore(s, t.nextSibling);
           }})(document, 'script');
         }
-    </script> -->
+    </script>
     <!-- Solution for getting opening to fit into Recruiterbox widget -->
-    <!-- <div class="rbox-opening-li" style="margin-top:-3rem;margin-bottom: 3rem;">
+    <div class="rbox-opening-li" style="margin-top:-3rem;">
       <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999799171175-chief-digital-services-officer-0953-" class="rbox-opening-li-title">
         Chief Digital Services Officer
       </a>
@@ -63,26 +63,17 @@ the_type = "job-index"
           <small class="rbox-opening-position-type">Full-time</small>
         </span>
       </div>
-    </div> -->
-    <div class="rbox-opening-li" style="margin-bottom: 3rem;">
-      <h4>
-        <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999799171175-chief-digital-services-officer-0953-" class="rbox-opening-li-title">
-        Chief Digital Services Officer
-        </a>
-      </h4>
-      <p>
-        Location: San Francisco, California, United States
-      </p>
     </div>
     <div class="rbox-opening-li" style="margin-bottom: 3rem;">
-      <h4>
-        <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999801085935-product-manager-for-platforms-infrastructure-digital-services-9976-1053-" class="rbox-opening-li-title">
-        Product Manager for Platforms and Infrastructure
-        </a>
-      </h4>
-      <p>
+      <a href="https://jobs.smartrecruiters.com/CityAndCountyOfSanFrancisco1/743999801085935-product-manager-for-platforms-infrastructure-digital-services-9976-1053-" class="rbox-opening-li-title">
+      Product Manager for Platforms and Infrastructure
+      </a>
+      <div class="rbox-job-shortdesc">
         Location: San Francisco, California, United States
-      </p>
+        <span class="rbox-opening-position-info">
+          <small class="rbox-opening-position-type">Full-time</small>
+        </span>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
We removed recruiterbox in https://github.com/SFDigitalServices/sfdigitalservices/pull/111/files because there weren't any open recruiterbox listings, so "join us" was looking like 

<img width="787" alt="image" src="https://user-images.githubusercontent.com/11825994/154117952-11da895a-2847-4d67-9619-273905a32cc1.png">

We're going to add some new roles on recruiterbox today (?) so we need to add the widget back.

Hopefully soon this will be moved to SF.gov, but for now, this was my best idea for how to combine recruiterbox and smart recruiters posts. 

This isn't ready to go to prod until there's actually a listing posted on recruiterbox. 