### PR TITLE
Add "Program Manager, Strategic Initiatives" role

### DIFF
--- a/content/joinus.html
+++ b/content/joinus.html
@@ -3,6 +3,8 @@ aliases:
   - /joinus.html
 type: jobs
 roles:
+  - title: Program Manager, Strategic Initiatives
+    url: https://careers.sf.gov/role/?id=3743990000627536
   - title: Senior QA Engineer
     url: https://jobs.smartrecruiters.com/ni/CityAndCountyOfSanFrancisco1/070dc0d7-d018-4f52-85fc-34756d7ca78c-senior-quality-assurance-engineer-digital-services-1043-
   - title: Digital Translation Project Manager

--- a/themes/digitalservices/layouts/jobs/single.html
+++ b/themes/digitalservices/layouts/jobs/single.html
@@ -34,7 +34,7 @@
 <!-- Services -->
 <div id="roadmap" class="container">
   <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-6 col-md-offset-3">
-    <h1 class="sub-heading">The Roles</h1>
+    <h1 class="sub-heading" id="roles">Open roles</h1>
     <hr class="separator center" />
     
     {{ range .Params.roles }}

--- a/themes/digitalservices/layouts/jobs/single.html
+++ b/themes/digitalservices/layouts/jobs/single.html
@@ -32,9 +32,9 @@
 <!-- <div id="separator-image-2" style="background-image:url('/assets/open-chair.jpg');"></div> -->
 
 <!-- Services -->
-<div id="roadmap" class="container">
-  <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-6 col-md-offset-3">
-    <h1 class="sub-heading" id="roles">Open roles</h1>
+<div id="roles" class="container">
+  <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-6 col-md-offset-3" id="roadmap">
+    <h1 class="sub-heading">Open roles</h1>
     <hr class="separator center" />
     
     {{ range .Params.roles }}


### PR DESCRIPTION
This PR adds the "Program Manager, Strategic Initiatives" role to our [Join us page](https://sfdigitalservices-pr-128.herokuapp.com/joinus/#roles) and:

- Changes the heading "The Roles" to "Open roles" (without changing the `text-transform: uppercase` style 😢 )
- Renames the "roadmap" ID to "roles" so you can link to `/joinus/#roles` directly